### PR TITLE
fix: Correct invalid vercel.json rewrite rule

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -82,7 +82,7 @@
     },
 
     {
-      "source": "/((?!api/).*)",
+      "source": "/:path((?!api/).*)",
       "destination": "/index.html"
     }
   ]


### PR DESCRIPTION
The rewrite rule for the SPA fallback was using a regular expression with an unnamed capture group, which caused a `path-to-regexp` error during Vercel deployment.

This change adds a named parameter to the rewrite rule's `source` path to resolve the error.